### PR TITLE
Add support for dynamodb data and session lifetime custom fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Vagrantfile
 .DS_Store
 .vscode
 .jshintrc
+/.buildpath
+/.project
+/.settings
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php" : ">=5.4",
-    "aws/aws-sdk-php": "~3.0",
+    "aws/aws-sdk-php": "~3.93.6",
     "illuminate/support": "~5.0"
   },
   "require-dev": {

--- a/config/dynamodb-session.php
+++ b/config/dynamodb-session.php
@@ -1,9 +1,8 @@
 <?php
 return [
-
     /*
     |--------------------------------------------------------------------------
-    | AWS Configuration details
+    | AWS Configuration Details
     |--------------------------------------------------------------------------
     |
     */
@@ -14,9 +13,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hash key
+    | DynamoDB Session Configuration Details
     |--------------------------------------------------------------------------
-    | Name of hash key in table. Default: "id".
+    |
     */
+    // Name of table to store the sessions. Default: config('session.table')
+    'table_name' => env( 'DYNAMO_SESSIONS_TABLE', config('session.table') ),
+
+    // Name of hash key in table. Default: "id"
     'hash_key' => env('DYNAMODB_HASH_KEY', 'id'),
+
+    // Name of the data attribute in table. Default: "data"
+    'data_attribute' => env('DYNAMODB_DATA_ATTRIBUTE', 'data'),
+
+    // Name of the session life time attribute in table. Default: "expires"
+    'session_lifetime_attribute' => env('DYNAMODB_SESSION_LIFETIME_ATTRIBUTE', 'expires')
 ];

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@ This package is a Laravel Session Driver for [DynamoDB](https://aws.amazon.com/d
 ## Installation
 This package can be installed through Composer.
 
-```
-composer require oryxcloud/laravel-dynamodb-session-driver
+```shell
+$ composer require oryxcloud/laravel-dynamodb-session-driver
 ```
 
 After updating composer, add the service provider to the `providers` array in `config/app.php`
 
-```
+```php
 'providers' => [
     ...
     OryxCloud\DynamoDbSessionDriver\SessionServiceProvider::class,
@@ -21,19 +21,18 @@ After updating composer, add the service provider to the `providers` array in `c
 
 You can publish the config file of this package with this command:
 
-```
-php artisan vendor:publish --provider="OryxCloud\DynamoDbSessionDriver\SessionServiceProvider"
+```shell
+$ php artisan vendor:publish --provider="OryxCloud\DynamoDbSessionDriver\SessionServiceProvider"
 ```
 
 The following config file will be published in `config/dynamodb-session.php`
 
-```
+```php
 <?php
 return [
-
     /*
     |--------------------------------------------------------------------------
-    | AWS Configuration details
+    | AWS Configuration Details
     |--------------------------------------------------------------------------
     |
     */
@@ -44,11 +43,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hash key
+    | DynamoDB Session Configuration Details
     |--------------------------------------------------------------------------
-    | Name of hash key in table. Default: "id".
+    |
     */
+    // Name of table to store the sessions. Default: config('session.table')
+    'table_name' => env( 'DYNAMO_SESSIONS_TABLE', config('session.table') ),
+
+    // Name of hash key in table. Default: "id"
     'hash_key' => env('DYNAMODB_HASH_KEY', 'id'),
+
+    // Name of the data attribute in table. Default: "data"
+    'data_attribute' => env('DYNAMODB_DATA_ATTRIBUTE', 'data'),
+
+    // Name of the session life time attribute in table. Default: "expires"
+    'session_lifetime_attribute' => env('DYNAMODB_SESSION_LIFETIME_ATTRIBUTE', 'expires')
 ];
 
 ```
@@ -59,13 +68,14 @@ You should also add the specified keys in your `.env` file.
 
 After going through all the installation steps, the `dynamodb` Session driver will now be available to be used. So you can just change the following line in your `.env` file.
 
-```
+```shell
 SESSION_DRIVER=dynamodb
 ```
 
 ## Contributors
 - [Mozammil Khodabacchas](https://github.com/mozammil)
 - [Jomit Jose](https://github.com/jomoos)
+- [Alessio Nobile](https://github.com/alessionobile)
 
 ## Credits
 [DynamoDb Session Handler for Symfony 2](https://github.com/gwkunze/dynamo-session-bundle)
@@ -73,4 +83,3 @@ SESSION_DRIVER=dynamodb
 ## License
 
 The MIT License (MIT). Please see [License File](license.md) for more information.
-

--- a/src/SessionServiceProvider.php
+++ b/src/SessionServiceProvider.php
@@ -32,9 +32,11 @@ class SessionServiceProvider extends ServiceProvider
             ]);
 
             $config = [
-                'table_name'       => config('session.table'),
+                'table_name'       => config('dynamodb-session.table_name'),
                 'hash_key'         => config('dynamodb-session.hash_key'),
-                'session_lifetime' => 60 * config('session.lifetime')
+                'data_attribute'         => config('dynamodb-session.data_attribute'),
+                'session_lifetime' => 60 * config('session.lifetime'),
+                'session_lifetime_attribute' => config('dynamodb-session.session_lifetime_attribute')
             ];
 
             return new DynamoHandler($client, $config);


### PR DESCRIPTION
Hi there,

I've added the support for custom data and session lifetime attributes. So that we can extend the configuration and use this library in cases of pre-existing DynamoDB session tables with field names differing from the default ones that were provided with the prev versions of aws-sdk-php.

As a result of this PR submitted to aws - which is merged to master and available under the v 3.93.6 
https://github.com/aws/aws-sdk-php/pull/1784

Looking forward to your feedback guys. Thanks